### PR TITLE
enforceOneRow does not cover zero rows

### DIFF
--- a/models/serialization.go
+++ b/models/serialization.go
@@ -84,6 +84,9 @@ func enforceOneRow(r *sql.Rows, debugname string, fn func(r SingleRow) error) er
 		}
 		n++
 	}
+	if n == 0 {
+		return fmt.Errorf("%s: zero database rows retrieved when enforcing one row", debugname)
+	}
 	return r.Err()
 }
 


### PR DESCRIPTION
this leads to invalid memory address or nil pointer dereference in later transactions